### PR TITLE
fix:moved cta buttons in the add and delete screens to animate above the list

### DIFF
--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/LocationNavGraph.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/LocationNavGraph.kt
@@ -6,6 +6,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import com.gear.add_remove_location.presentation.manage_location.ManageLocationScreen
 import com.gear.add_remove_location.presentation.manage_location.SaveLocationScreen
+import com.gear.add_remove_location.presentation.manage_location.util.EnterScreenAnimation
 
 @Composable
 fun SetUpNavGraph(
@@ -17,23 +18,28 @@ fun SetUpNavGraph(
         navController = navController,
         startDestination = LocationScreen.Save.route
     ) {
+
         composable(
             route = LocationScreen.Manage.route
         ) {
-            ManageLocationScreen(
-                viewModel = viewModel,
-                navController = navController
-            )
+            EnterScreenAnimation {
+                ManageLocationScreen(
+                    viewModel = viewModel,
+                    navController = navController
+                )
+            }
         }
 
         composable(
             route = LocationScreen.Save.route
         ) {
-            SaveLocationScreen(
-                onNavBack = onNavBack,
-                viewModel = viewModel,
-                navController = navController
-            )
+            EnterScreenAnimation {
+                SaveLocationScreen(
+                    onNavBack = onNavBack,
+                    viewModel = viewModel,
+                    navController = navController
+                )
+            }
         }
     }
 }

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/ManageLocationScreen.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/ManageLocationScreen.kt
@@ -22,7 +22,7 @@ import androidx.navigation.NavController
 import com.gear.add_remove_location.R
 import com.gear.add_remove_location.presentation.LocationViewModel
 import com.gear.add_remove_location.presentation.manage_location.components.CustomMenuItem
-import com.gear.add_remove_location.presentation.manage_location.components.actions.EditAction
+import com.gear.add_remove_location.presentation.manage_location.components.actions.DeleteAction
 import com.gear.add_remove_location.presentation.manage_location.components.actions.SearchAction
 import com.gear.add_remove_location.presentation.manage_location.components.drawDropShadow
 import com.gear.add_remove_location.presentation.ui.theme.LocationTitleStyle
@@ -142,7 +142,7 @@ fun ManageLocationScreen(
                         )
                     }
                     Action.EDIT -> {
-                        EditAction(
+                        DeleteAction(
                             savedLocations = viewModel.savedLocations.value,
                             onDeleteItemSelected = { index, location, isSelected ->
                                 viewModel.deleteItemSelected(

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/SaveLocationScreen.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/SaveLocationScreen.kt
@@ -1,10 +1,7 @@
 package com.gear.add_remove_location.presentation.manage_location
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
@@ -57,7 +54,10 @@ fun SaveLocationScreen(
                 },
                 actions = {
                     IconButton(onClick = { expanded = true }) {
-                        Icon(imageVector = Icons.Default.MoreVert, contentDescription = stringResource(id = R.string.menu))
+                        Icon(
+                            imageVector = Icons.Default.MoreVert,
+                            contentDescription = stringResource(id = R.string.menu)
+                        )
                     }
                 }
             )
@@ -73,20 +73,30 @@ fun SaveLocationScreen(
             ) {
                 DropdownMenu(
                     expanded = expanded,
-                    onDismissRequest = { expanded = false},
-                modifier = Modifier) {
-                    CustomMenuItem(
-                    imageVector = Icons.Outlined.AddLocation,
-                    action = stringResource(id = R.string.add)
+                    onDismissRequest = { expanded = false },
+                    modifier = Modifier
                 ) {
+                    CustomMenuItem(
+                        imageVector = Icons.Outlined.AddLocation,
+                        action = stringResource(id = R.string.add)
+                    ) {
+                        expanded = false
                         viewModel.setSearchState("")
                         viewModel.setAction(Action.SEARCH_SAVE)
                         navController.navigate(LocationScreen.Manage.route)
                     }
+                    Spacer(
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp)
+                            .height(2.dp)
+                            .background(MaterialTheme.colors.primary.copy(0.75f))
+                    )
                     CustomMenuItem(
                         imageVector = Icons.Outlined.DeleteForever,
                         action = stringResource(id = R.string.delete)
                     ) {
+                        expanded = false
                         viewModel.setAction(Action.EDIT)
                         navController.navigate(LocationScreen.Manage.route)
                     }

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/components/actions/DeleteAction.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/components/actions/DeleteAction.kt
@@ -1,5 +1,6 @@
 package com.gear.add_remove_location.presentation.manage_location.components.actions
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
@@ -18,11 +19,10 @@ import com.gear.add_remove_location.presentation.manage_location.components.Loca
 import com.gear.add_remove_location.presentation.manage_location.components.drawDropShadow
 import com.gear.add_remove_location.presentation.ui.theme.ButtonTextStyle
 import com.gear.add_remove_location.presentation.ui.theme.LocationSubStyle
-import com.gear.add_remove_location.presentation.ui.theme.Primary500
 import com.gear.weathery.location.api.Location
 
 @Composable
-fun EditAction(
+fun DeleteAction(
     savedLocations: List<Location>,
     onDeleteItemSelected: (index: Int, location: Location, isSelected: Boolean) -> Unit,
     cancelDelete: () -> Unit,
@@ -61,6 +61,36 @@ fun EditAction(
         )
     }
 
+    AnimatedVisibility(visible = items.any { it.isSelected }) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colors.background)
+                .padding(bottom = 16.dp)
+        ) {
+            Row(Modifier.align(Alignment.Center)) {
+                OutlinedButton(onClick = { cancelDelete() }, shape = RoundedCornerShape(4.dp)) {
+                    Text(
+                        text = stringResource(R.string.cancel),
+                        style = ButtonTextStyle,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(48.dp))
+                Button(
+                    onClick = { deleteLocations() },
+                    shape = RoundedCornerShape(4.dp),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = MaterialTheme.colors.secondary)
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.delete),
+                        style = ButtonTextStyle,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        }
+    }
 
     LazyColumn {
         items(items.size) { i ->
@@ -92,36 +122,6 @@ fun EditAction(
                         onDeleteItemSelected(i, items[i].location, items[i].isSelected)
                     }
                 )
-            }
-        }
-
-        item {
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .padding(bottom = 16.dp)
-            ) {
-                Row(Modifier.align(Alignment.Center)) {
-                    OutlinedButton(onClick = { cancelDelete() }, shape = RoundedCornerShape(4.dp)) {
-                        Text(
-                            text = stringResource(R.string.cancel),
-                            style = ButtonTextStyle,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(48.dp))
-                    Button(
-                        onClick = { deleteLocations() },
-                        shape = RoundedCornerShape(4.dp),
-                        colors = ButtonDefaults.buttonColors(backgroundColor = Primary500)
-                    ) {
-                        Text(
-                            text = stringResource(id = R.string.delete),
-                            style = ButtonTextStyle,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
-                    }
-                }
             }
         }
     }

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/components/actions/SaveAction.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/components/actions/SaveAction.kt
@@ -1,5 +1,6 @@
 package com.gear.add_remove_location.presentation.manage_location.components.actions
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
@@ -9,6 +10,7 @@ import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.gear.add_remove_location.R
@@ -16,7 +18,6 @@ import com.gear.add_remove_location.presentation.manage_location.SaveListItem
 import com.gear.add_remove_location.presentation.manage_location.components.LocationItem
 import com.gear.add_remove_location.presentation.manage_location.components.drawDropShadow
 import com.gear.add_remove_location.presentation.ui.theme.ButtonTextStyle
-import com.gear.add_remove_location.presentation.ui.theme.Gray500
 import com.gear.add_remove_location.presentation.ui.theme.Primary500
 import com.gear.weathery.location.api.Location
 
@@ -31,7 +32,7 @@ fun SaveAction(
     val query by remember { mutableStateOf(text) }
     Text(
         text = stringResource(R.string.locations_related) + "\"$query\"",
-        color = Gray500,
+        color = MaterialTheme.colors.primaryVariant,
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 24.dp)
     )
 
@@ -46,6 +47,40 @@ fun SaveAction(
         )
     }
 
+    AnimatedVisibility(visible = items.any { it.isSelected }) {
+        Box(
+            Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colors.background)
+                .padding(bottom = 16.dp)
+        ) {
+            Row(Modifier.align(Alignment.Center)) {
+                OutlinedButton(
+                    onClick = { cancelSave() },
+                    shape = RoundedCornerShape(4.dp)
+                ) {
+                    Text(
+                        text = stringResource(id = R.string.cancel),
+                        style = ButtonTextStyle,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+                Spacer(modifier = Modifier.width(48.dp))
+                Button(
+                    onClick = { saveLocations() },
+                    shape = RoundedCornerShape(4.dp),
+                    colors = ButtonDefaults.buttonColors(backgroundColor = MaterialTheme.colors.secondary)
+                ) {
+                    Text(
+                        text = stringResource(R.string.save),
+                        style = ButtonTextStyle,
+                        color = Color.White,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                    )
+                }
+            }
+        }
+    }
 
     LazyColumn {
         items(items.size) { i ->
@@ -70,36 +105,6 @@ fun SaveAction(
                     onItemSelected(i, items[i].location, items[i].isSelected)
                 }
                 .padding(16.dp))
-        }
-
-        item {
-            Box(
-                Modifier
-                    .fillMaxSize()
-                    .padding(bottom = 16.dp)
-            ) {
-                Row(Modifier.align(Alignment.Center)) {
-                    OutlinedButton(onClick = { cancelSave() }, shape = RoundedCornerShape(4.dp)) {
-                        Text(
-                            text = stringResource(id = R.string.cancel),
-                            style = ButtonTextStyle,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
-                    }
-                    Spacer(modifier = Modifier.width(48.dp))
-                    Button(
-                        onClick = { saveLocations() },
-                        shape = RoundedCornerShape(4.dp),
-                        colors = ButtonDefaults.buttonColors(backgroundColor = MaterialTheme.colors.secondary)
-                    ) {
-                        Text(
-                            text = stringResource(R.string.save),
-                            style = ButtonTextStyle,
-                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
-                        )
-                    }
-                }
-            }
         }
     }
 }

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/components/actions/SearchAction.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/components/actions/SearchAction.kt
@@ -1,9 +1,7 @@
 package com.gear.add_remove_location.presentation.manage_location.components.actions
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
+import androidx.compose.animation.Crossfade
+import androidx.compose.foundation.layout.*
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -27,6 +25,7 @@ fun SearchAction(
     saveLocations: () -> Unit,
     cancelSave: () -> Unit
 ) {
+
     Text(
         text = stringResource(R.string.add_new),
         modifier = Modifier
@@ -36,34 +35,44 @@ fun SearchAction(
     )
 
 
-    if (isOnSearch) {LocationSearchBar(
-        modifier = Modifier.padding(top = 16.dp), text = text,
-    ) { onLocationSearch(it) }
-        Box(
-            Modifier
-                .fillMaxSize()
-        ) {
-            if (text.isNotBlank()) {
-                SearchResultsWidget(
-                    modifier = Modifier.align(Alignment.TopCenter),
-                    list = locations.map {
-                        buildString {
-                            append(it.name)
-                            append(if (it.country.isNotBlank()) ", ${it.country}" else "")
+    Crossfade(targetState = isOnSearch) { onSearch ->
+        Column {
+            when (onSearch) {
+                true -> {
+                    LocationSearchBar(
+                        modifier = Modifier.padding(top = 16.dp), text = text,
+                    ) { onLocationSearch(it) }
+                    Box(
+                        Modifier
+                            .fillMaxSize()
+                    ) {
+                        if (text.isNotBlank()) {
+                            SearchResultsWidget(
+                                modifier = Modifier.align(Alignment.TopCenter),
+                                list = locations.map {
+                                    buildString {
+                                        append(it.name)
+                                        append(if (it.country.isNotBlank()) ", ${it.country}" else "")
+                                    }
+                                }.distinct()
+                            ) {
+                                onLocationSelected(it)
+                            }
                         }
-                    }.distinct()
-                ) {
-                    onLocationSelected(it)
+                    }
+                }
+                false -> {
+                    SaveAction(
+                        locations = locations,
+                        text = text,
+                        { index, location, isSelected ->
+                            onSaveItemClicked(index, location, isSelected)
+                        },
+                        { saveLocations() },
+                        { cancelSave() }
+                    )
                 }
             }
         }
-    } else SaveAction(
-        locations = locations,
-        text = text,
-        { index, location, isSelected ->
-            onSaveItemClicked(index, location, isSelected)
-        },
-        { saveLocations() },
-        { cancelSave() }
-    )
+    }
 }

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/util/EnterScreenAnimation.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/manage_location/util/EnterScreenAnimation.kt
@@ -1,0 +1,19 @@
+package com.gear.add_remove_location.presentation.manage_location.util
+
+import androidx.compose.animation.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+
+@Composable
+fun EnterScreenAnimation(content: @Composable () -> Unit) {
+    AnimatedVisibility(
+        visible = true,
+        enter = slideInVertically(
+            initialOffsetY = { -40 }
+        ) + expandVertically(
+            expandFrom = Alignment.Top
+        ) + fadeIn(initialAlpha = 0.3f),
+        exit = slideOutVertically() + shrinkVertically() + fadeOut(),
+        content = { content() },
+    )
+}

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/ui/theme/Color.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/ui/theme/Color.kt
@@ -2,7 +2,5 @@ package com.gear.add_remove_location.presentation.ui.theme
 
 import androidx.compose.ui.graphics.Color
 
-val Purple700 = Color(0xFF3700B3)
-val Teal200 = Color(0xFF03DAC5)
 val Primary500 = Color(0xFFEF6820)
 val Gray500 = Color(0xFF545454)

--- a/features/location/src/main/java/com/gear/add_remove_location/presentation/ui/theme/Theme.kt
+++ b/features/location/src/main/java/com/gear/add_remove_location/presentation/ui/theme/Theme.kt
@@ -9,16 +9,18 @@ import androidx.compose.ui.graphics.Color
 
 private val DarkColorPalette = darkColors(
     primary = Color.White,
-    primaryVariant = Purple700,
+    primaryVariant = Gray500,
     secondary = Primary500,
-    background = Color.Black
+    background = Color.Black,
+    surface = Color.Black
 )
 
 private val LightColorPalette = lightColors(
     primary = Color.Black,
-    primaryVariant = Purple700,
+    primaryVariant = Gray500,
     secondary = Primary500,
-    background = Color.White
+    background = Color.White,
+    surface = Color.White
 )
 
 @Composable


### PR DESCRIPTION
## Description

The following changes were made to achieve this:

- The buttons for save and delete actions were moved to toggle their visibility above the location list when a location is selected
- A divider was added between the dropdown menu items
- An animation class was added and used to animate between navigation in the composables
- The text color in the save and delete button was set to remain white in either theme

## Linear Ticket
https://linear.app/team-gear/issue/MOB-85/location

## Type of change
- [x] Fix (non-breaking change which fixes an issue)
- [x] Feat (non-breaking change which adds functionality)
- [ ] Breaking change (Add a ! to Fix/Feat) (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Preview
![save-demo](https://user-images.githubusercontent.com/40097879/206925643-1c04d814-d5f4-44fa-a120-4e9d5e48a250.gif) ![delete-demo](https://user-images.githubusercontent.com/40097879/206925654-ec6cd45a-6461-47b7-8659-04f6a518c0c9.gif)

- Provide a link of the Project design used below
[Design](https://www.figma.com/file/0MDrFN0qXRJBzApi9s9snN/Team-Gear-Weather-App?node-id=1730%3A49029&t=a4wUJ52nubF7tMDG-0)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] All dependencies used have been well documented on PR
- [x] I have checked my code and corrected any misspellings
- [x] New and existing unit tests pass locally with my changes
- [x] You are using approved terminology and naming guidelines

## Did you test this feature on all devices

Yes, tested with the following devices

- [x] Emulated Device (Mobile / Tablets)
- [x] Live Device (Mobile / Tablets)
