### PR TITLE
fix(dashboard): fixed notification always poping up on app start

### DIFF
--- a/app/src/main/java/com/gear/weathery/MainActivity.kt
+++ b/app/src/main/java/com/gear/weathery/MainActivity.kt
@@ -131,9 +131,12 @@ class MainActivity : AppCompatActivity() {
         notificationDao.getNotifications().asLiveData().observe(this){
             lifecycleScope.launch {
 
-                if(it.isEmpty()){
+                val notificationsAlreadyRead = settingsPreference.unreadNotificationCounterFlow().first() == 0
+
+                if(it.isEmpty() || notificationsAlreadyRead){
                     return@launch
                 }
+
                 val notification = it.last()
                 binding.notificationBodyTextView.text = notification.notificationText
                 binding.popupNotification.visibility = View.VISIBLE

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -35,6 +35,7 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@drawable/bg_bottom_notification"
+        android:visibility="invisible"
         android:paddingBottom="56dp"
         android:layout_marginHorizontal="16dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/features/setting/src/main/java/com/gear/weathery/setting/notifications/utils/NotificationUtil.kt
+++ b/features/setting/src/main/java/com/gear/weathery/setting/notifications/utils/NotificationUtil.kt
@@ -47,11 +47,12 @@ fun processNotificationData(
     val scope = CoroutineScope(Job() + Dispatchers.Main)
 
     scope.launch {
+
+        incrementUnreadNotificationCounter(settingsPreference)
+
         val notificationData =
             NotificationData(event, body, dateTime)
         notificationDao.insert(notificationData)
-
-
 
         if (!settingsPreference.getAppForegroundStatus()){
             (ContextCompat.getSystemService(
@@ -60,7 +61,6 @@ fun processNotificationData(
             ) as NotificationManager).sendNotification(context, event, body)
         }
 
-        incrementUnreadNotificationCounter(settingsPreference)
     }
 }
 


### PR DESCRIPTION
## Description
notification was popping up every time the app is started

Fixes # (issue)

- notification popping up only when there is a new notification or on app start if there is old unread notification

## Major Changes
- [ ] Added feature
- [ ] Removed feature

## Linear Ticket
- [ ] Does this PR address a linear issue ticket?
- _If yes, provide the ticket ID in this space..._

## Type of change
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feat (non-breaking change which adds functionality)
- [ ] Breaking change (Add a ! to Fix/Feat) (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Preview
- All PRs that include new features should have video/screenshots of how said feature works present in the PR
- [ ] Has this been accomplished?
- Provide a link of the Project design used below



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] All dependencies used have been well documented on PR
- [x] I have checked my code and corrected any misspellings
- [x] New and existing unit tests pass locally with my changes
- [x] You are using approved terminology and naming guidelines

## Did you test this feature on all devices

Yes, tested with the following devices

- [ ] Emulated Device (Mobile / Tablets)
- [x] Live Device (Mobile / Tablets)
